### PR TITLE
Rename to to 'cbra_contracts'

### DIFF
--- a/cbra_contracts.gemspec
+++ b/cbra_contracts.gemspec
@@ -5,7 +5,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'cbra_contracts/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'CBRA-Contracts'
+  spec.name          = 'cbra_contracts'
   spec.version       = CBRAContracts::VERSION
   spec.authors       = ['Blue Bottle Coffee']
   spec.email         = ['opensource@bluebottlecoffee.com']


### PR DESCRIPTION
We don't want people to install gem install CBRA-Contracts. Not
idiomatic :-(