### PR TITLE
Kylew/nil is ok

### DIFF
--- a/lib/cbra_contracts/contract_method.rb
+++ b/lib/cbra_contracts/contract_method.rb
@@ -44,9 +44,9 @@ module CBRAContracts
       schema = Dry::Schema::DSL.new
       params.each do |p|
         if p.required?
-          schema.required(p.name).filled(p.type)
+          schema.required(p.name).maybe(p.type)
         else
-          schema.optional(p.name).filled(p.type)
+          schema.optional(p.name).maybe(p.type)
         end
       end
 

--- a/lib/cbra_contracts/version.rb
+++ b/lib/cbra_contracts/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CBRAContracts
-  VERSION = '0.4.0b'
+  VERSION = '0.4.1b'
 end

--- a/test/contract_method_test.rb
+++ b/test/contract_method_test.rb
@@ -32,6 +32,10 @@ class ContactMethodTest < Minitest::Test
     assert wrong_types.message.include?('Argument [:str] must be a string')
   end
 
+  def test_nullable_values
+    assert_equal :ok, @contract_method.invoke(valid_params.merge(str: nil))
+  end
+
   def test_extra_params_are_filtered
     mock_impl = Minitest::Mock.new
     mock_impl.expect(:call, true, [valid_params])


### PR DESCRIPTION
This changes the Dry::Schema to use a Maybe macro
See: https://github.com/dry-rb/dry-schema/blob/release-1.5/lib/dry/schema/macros/maybe.rb

Parameters can still be required _or_ optional, but pass nil