### PR TITLE
Kylew/fix no args

### DIFF
--- a/lib/cbra_contracts/dsl.rb
+++ b/lib/cbra_contracts/dsl.rb
@@ -44,7 +44,7 @@ module CBRAContracts
     # Class private; not meant to be used publicly
     def define_component_contract_method(contract_method)
       @@component.module_eval do
-        self.define_method(contract_method.name) do |args|
+        self.define_method(contract_method.name) do |args = {}|
           contract_method.invoke(args)
         end
         module_function contract_method.name

--- a/lib/cbra_contracts/version.rb
+++ b/lib/cbra_contracts/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module CBRAContracts
-  VERSION = '0.5.1b'
+  VERSION = '0.5.2b'
 end

--- a/test/dsl_test.rb
+++ b/test/dsl_test.rb
@@ -14,10 +14,20 @@ class DslTest < Minitest::Test
         m.param :why, :integer, 'A secret testing code'
         m.produces TestOutput
       end
+
+      contract_method :no_args, 'A method with no args' do |m|
+        m.produces TestOutput
+      end
     end
 
     class JustTestIt
       def call(*_args)
+      end
+    end
+
+    class NoArg
+      def call
+        TestOutput.new(true)
       end
     end
   end
@@ -54,5 +64,10 @@ class DslTest < Minitest::Test
 
     # Reset it so future tests don't use mocked implementation
     contract_method.implementation = nil
+  end
+
+  def test_contract_method_with_no_args
+    assert TestComponent.respond_to? :no_args
+    assert TestComponent.no_args.works
   end
 end


### PR DESCRIPTION
Added the ability to have methods with no args in https://github.com/bluebottlecoffee/CBRA-Contracts/pull/17/files

But the DSL didn't get the memo

For comfort that this is actually fixing the error we're seeing in OP, here's the test prior to the fix in `dsl.rb` showing the same error

![Image 2021-03-23 at 9 09 40 AM](https://user-images.githubusercontent.com/101163/112179132-a3e67e80-8bb7-11eb-8298-ebe4429e611f.jpg)
